### PR TITLE
Add external-scripts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,11 @@ In your `package.json`, add the following line to the dependencies:
    "hubot-standup": "git://github.com/miyagawa/hubot-standup.git"
 ```
 
-Then run `npm install` and create a symbolic link from `scripts` directory:
+Then run `npm install` and add `hubot-standup` to `external-scripts.json`. E.g.:
 
 ```
-ln -s ../node_modules/hubot-standup/src/scripts/standup.coffee scripts/
+["hubot-standup"]
 ```
-
-Add the symlink file to the git repository if necessary (for Heroku deployment).
 
 ### Yammer
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,8 @@
+Fs   = require 'fs'
+Path = require 'path'
+
+module.exports = (robot) ->
+  path = Path.resolve __dirname, 'src/scripts'
+  Fs.exists path, (exists) ->
+    if exists
+      robot.loadFile path, file for file in Fs.readdirSync(path)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "engines": {
     "node": "> 0.6.0"
   },
+  "main": "index.coffee",
   "dependencies": {
     "coffee-script": "> 1.1.3"
   },


### PR DESCRIPTION
This means `hubot-standup` can be put in `external-scripts.json` and everything kind of works.
