### PR TITLE
Match only non-whitespace characters as team or member names

### DIFF
--- a/src/scripts/standup.coffee
+++ b/src/scripts/standup.coffee
@@ -7,7 +7,7 @@ module.exports = (robot) ->
     delete robot.brain.data.standup?[msg.message.user.room]
     msg.send "Standup cancelled"
 
-  robot.respond /standup for (.*) *$/i, (msg) ->
+  robot.respond /standup for (\S+)\s*$/i, (msg) ->
     room  = msg.message.user.room
     group = msg.match[1].trim()
     if robot.brain.data.standup?[room]
@@ -42,7 +42,7 @@ module.exports = (robot) ->
     else
       nextPerson robot, msg.message.user.room, msg
 
-  robot.respond /(skip|next) (.*) *$/i, (msg) ->
+  robot.respond /(skip|next) (\S+)\s*$/i, (msg) ->
     unless robot.brain.data.standup?[msg.message.user.room]
       return
 


### PR DESCRIPTION
Hi
It's a small fix to match only non-whitespace characters, it's quite annoying when using tab completion as many (most?) IRC clients add a space that's also part of the match.