### PR TITLE
Roles work with hubot-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ hubot: Ok, john is an engineering member
 miyagawa: hubot davidlee is an engineering member
 hubot: Ok, davidlee is an engineering member
 ```
+Or if using [hubot-auth](https://www.npmjs.com/package/hubot-auth):
+
+```
+miyagawa: hubot miyagawa has engineering role
+hubot: OK, miyagawa has the engineering role
+```
 
 You can create as many teams as you want.
 
@@ -64,6 +70,8 @@ hubot: All done! Standup was 5 minutes and 24 seconds.
 ## Installation
 
 This hubot script depends on `roles.coffee` script. You're recommended to use `redis-brain.coffee` to persist the team information.
+
+You can use the [hubot-auth](https://www.npmjs.com/package/hubot-auth) module to manage roles as well.
 
 In your project directory, run the following:
 

--- a/src/scripts/standup.coffee
+++ b/src/scripts/standup.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
     attendees = []
     for own key, user of robot.brain.data.users
       roles = user.roles or [ ]
-      if "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
+      if "#{group}" in roles or "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
         attendees.push user
     if attendees.length > 0
       robot.brain.data.standup or= {}

--- a/src/scripts/standup.coffee
+++ b/src/scripts/standup.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
     attendees = []
     for own key, user of robot.brain.data.users
       roles = user.roles or [ ]
-      if "#{group}" in roles or "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
+      if #{group} in roles or "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
         attendees.push user
     if attendees.length > 0
       robot.brain.data.standup or= {}

--- a/src/scripts/standup.coffee
+++ b/src/scripts/standup.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
     attendees = []
     for own key, user of robot.brain.data.users
       roles = user.roles or [ ]
-      if #{group} in roles or "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
+      if group in roles or "a #{group} member" in roles or "an #{group} member" in roles or "a member of #{group}" in roles
         attendees.push user
     if attendees.length > 0
       robot.brain.data.standup or= {}


### PR DESCRIPTION
We use hubot-auth for role management. I don't know where to find `roles.coffee` like it says to use in the readme. I assume a lot of other people use hubot-auth as well.

With hubot-auth, `role = "engineering"` instead of `role = "a member of engineering"`

This change allows the script to use hubot-auth for role management.

