### PR TITLE
Made can't find group line easier to understand

### DIFF
--- a/src/scripts/standup.coffee
+++ b/src/scripts/standup.coffee
@@ -42,7 +42,7 @@ module.exports = (robot) ->
       msg.send "Ok, let's start the standup: #{who}"
       nextPerson robot, room, msg
     else
-      msg.send "Oops, can't find anyone with 'a #{group} member' role!"
+      msg.send "Oops, can't find anyone with a '#{group}' member role!"
 
   robot.respond /(?:that\'s it|next(?: person)?|done) *$/i, (msg) ->
     unless robot.brain.data.standup?[msg.message.user.room]


### PR DESCRIPTION
Changed       msg.send "Oops, can't find anyone with 'a #{group} member' role!"
to       msg.send "Oops, can't find anyone with a '#{group}' member role!"

Better reflects emphasis on the variable as it is '#{group}' that is the user input, not 'a #{group} member'.
i.e. A user types
hubot standup for engineering

not

hubot standup for a engineering member

Might seem pedantic but it confused me for a bit while troubleshooting why the 'standup for' command isn't working for me.
